### PR TITLE
chore: bump compileSdk/targetSdk to 37

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Android Week View is a Kotlin Android library for displaying weekly schedules/ti
 - **Package**: `de.tobiasschuerg.weekview`
 - **Modules**: `library/` (the published library) and `app/` (sample/demo app)
 - **Distribution**: JitPack from GitHub tags
-- **Min SDK**: 26, **Compile/Target SDK**: 36, **Java**: 17 toolchain
+- **Min SDK**: 26, **Compile/Target SDK**: 37, **Java**: 17 toolchain
 - Kotlin uses AGP 9.0 built-in Kotlin support (no separate `kotlin-android` plugin)
 - Dependency versions are in `gradle/libs.versions.toml`
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,12 +12,12 @@ java {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "de.tobiasschuerg.weekview.sample"
         minSdk = 26
-        targetSdk = 36
+        targetSdk = 37
         versionCode = 1
         versionName = libVersion
     }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -13,7 +13,7 @@ java {
 android {
     defaultConfig {
         minSdk = 26
-        compileSdk = 36
+        compileSdk = 37
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -47,11 +47,11 @@ android {
     namespace = "de.tobiasschuerg.weekview"
 
     lint {
-        targetSdk = 36
+        targetSdk = 37
     }
 
     testOptions {
-        targetSdk = 36
+        targetSdk = 37
     }
 }
 

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/components/DayHeaderRow.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/components/DayHeaderRow.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -18,6 +19,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.os.ConfigurationCompat
 import de.tobiasschuerg.weekview.compose.style.WeekViewStyle
 import de.tobiasschuerg.weekview.compose.style.defaultWeekViewStyle
 import de.tobiasschuerg.weekview.data.EventConfig
@@ -38,6 +40,9 @@ internal fun DayHeaderRow(
     highlightCurrentDay: Boolean = true,
     eventConfig: EventConfig = EventConfig(),
 ) {
+    val configuration = LocalConfiguration.current
+    val locale = ConfigurationCompat.getLocales(configuration).get(0) ?: Locale.getDefault()
+
     Row {
         Box(modifier = Modifier.size(leftOffsetDp, topOffsetDp))
         days.forEach { date ->
@@ -71,11 +76,11 @@ internal fun DayHeaderRow(
                 }
             val dayName =
                 if (eventConfig.alwaysUseFullName) {
-                    date.dayOfWeek.getDisplayName(FULL, Locale.getDefault())
+                    date.dayOfWeek.getDisplayName(FULL, locale)
                 } else {
-                    date.dayOfWeek.getDisplayName(SHORT, Locale.getDefault())
+                    date.dayOfWeek.getDisplayName(SHORT, locale)
                 }
-            val shortDate = date.toShortDateStringWithoutYear()
+            val shortDate = date.toShortDateStringWithoutYear(locale)
             Column(
                 modifier = boxModifier,
                 horizontalAlignment = Alignment.CenterHorizontally,

--- a/library/src/main/java/de/tobiasschuerg/weekview/util/LocalDateExt.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/util/LocalDateExt.kt
@@ -13,8 +13,7 @@ import java.util.Locale
  *
  * Example outputs: "2/18" (US), "18.02." (Germany), "18/02" (UK)
  */
-internal fun LocalDate.toShortDateStringWithoutYear(): String {
-    val locale = Locale.getDefault()
+internal fun LocalDate.toShortDateStringWithoutYear(locale: Locale = Locale.getDefault()): String {
     val localizedPattern =
         DateTimeFormatterBuilder.getLocalizedDateTimePattern(
             FormatStyle.SHORT,


### PR DESCRIPTION
## Summary
- Bumps compileSdk/targetSdk from 36 to 37 in both `app` and `library`, required to unblock the open Dependabot PRs bumping `androidx.core:core-ktx` (#78) and `androidx.lifecycle` (#77), both of which need compileSdk 37+.
- Fixes a pre-existing `NonObservableLocale` lint error in `DayHeaderRow.kt` (a newer lint check, pulled in transitively, now catches a `Locale.getDefault()` read directly inside a composable body) — also needed to unblock the `compose-bom` bump (#76).

## Test plan
- [x] `./gradlew clean build` (unit tests + lint) passes locally with compileSdk 37
- [x] `./gradlew connectedDebugAndroidTest` passes on a physical device