### PR TITLE
feat: hoist WeekView zoom/scroll state, add day-click, and localize day headers

### DIFF
--- a/app/src/main/java/de/tobiasschuerg/weekview/sample/ComposeWeekViewActivity.kt
+++ b/app/src/main/java/de/tobiasschuerg/weekview/sample/ComposeWeekViewActivity.kt
@@ -141,6 +141,9 @@ class ComposeWeekViewActivity : ComponentActivity() {
                                 onScalingFactorChange = {
                                     Log.d("WeekView", "Scaling factor: $it")
                                 },
+                                onDayClick = { date ->
+                                    Toast.makeText(this@ComposeWeekViewActivity, "Clicked day: $date", Toast.LENGTH_SHORT).show()
+                                },
                             ),
                     )
                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.2.1"
+agp = "9.3.1"
 kotlin = "2.3.20"
 compose-bom = "2026.06.01"
 ktlint = "14.2.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.3.1"
+agp = "9.2.1"
 kotlin = "2.3.20"
 compose-bom = "2026.06.01"
 ktlint = "14.2.0"

--- a/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/EventClickabilityAccessibilityTest.kt
+++ b/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/EventClickabilityAccessibilityTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import de.tobiasschuerg.weekview.data.Event

--- a/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/EventClickabilityAccessibilityTest.kt
+++ b/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/EventClickabilityAccessibilityTest.kt
@@ -1,0 +1,142 @@
+package de.tobiasschuerg.weekview.compose
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import de.tobiasschuerg.weekview.data.Event
+import de.tobiasschuerg.weekview.data.LocalDateRange
+import de.tobiasschuerg.weekview.data.WeekViewConfig
+import de.tobiasschuerg.weekview.util.TimeSpan
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.time.LocalDate
+import java.time.LocalTime
+
+/**
+ * Verifies that events are only exposed as enabled/actionable to accessibility services when a
+ * click or long-press handler is actually supplied, matching the DayHeaderRow behavior. Without a
+ * handler, `combinedClickable(enabled = false)` still registers an OnClick semantics action but
+ * marks the node disabled, which is what changes how screen readers announce it.
+ */
+@RunWith(AndroidJUnit4::class)
+class EventClickabilityAccessibilityTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private val testDate: LocalDate = LocalDate.of(2025, 9, 2)
+    private val dateRange = LocalDateRange(testDate, testDate.plusDays(2))
+
+    @Test
+    fun singleEventWithoutHandlersIsDisabled() {
+        val event =
+            Event.Single(
+                id = 1L,
+                date = testDate,
+                title = "Test Event",
+                shortTitle = "Test",
+                timeSpan = TimeSpan(LocalTime.of(9, 0), LocalTime.of(10, 0)),
+                textColor = 0xFF000000.toInt(),
+                backgroundColor = 0xFF00FF00.toInt(),
+            )
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                WeekBackgroundCompose(
+                    dateRange = dateRange,
+                    events = listOf(event),
+                    timeRange = event.timeSpan,
+                    weekViewConfig = WeekViewConfig(),
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("EventView_1").assertIsNotEnabled()
+    }
+
+    @Test
+    fun singleEventWithClickHandlerIsEnabledAndClickable() {
+        val event =
+            Event.Single(
+                id = 2L,
+                date = testDate,
+                title = "Test Event",
+                shortTitle = "Test",
+                timeSpan = TimeSpan(LocalTime.of(9, 0), LocalTime.of(10, 0)),
+                textColor = 0xFF000000.toInt(),
+                backgroundColor = 0xFF00FF00.toInt(),
+            )
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                WeekBackgroundCompose(
+                    dateRange = dateRange,
+                    events = listOf(event),
+                    timeRange = event.timeSpan,
+                    weekViewConfig = WeekViewConfig(),
+                    onEventClick = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("EventView_2").assertIsEnabled().assertHasClickAction()
+    }
+
+    @Test
+    fun allDayEventWithoutHandlersIsDisabled() {
+        val event =
+            Event.AllDay(
+                id = 3L,
+                date = testDate,
+                title = "Holiday",
+                shortTitle = "Holiday",
+                textColor = 0xFF000000.toInt(),
+                backgroundColor = 0xFF00FF00.toInt(),
+            )
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                WeekBackgroundCompose(
+                    dateRange = dateRange,
+                    allDayEvents = listOf(event),
+                    timeRange = TimeSpan.of(LocalTime.of(9, 0), java.time.Duration.ofHours(1)),
+                    weekViewConfig = WeekViewConfig(),
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("AllDayEventView_3").assertIsNotEnabled()
+    }
+
+    @Test
+    fun multiDayEventWithoutHandlersIsDisabled() {
+        val event =
+            Event.MultiDay(
+                id = 4L,
+                date = testDate,
+                title = "Conference",
+                shortTitle = "Conference",
+                lastDate = testDate.plusDays(1),
+                textColor = 0xFF000000.toInt(),
+                backgroundColor = 0xFF00FF00.toInt(),
+            )
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                WeekBackgroundCompose(
+                    dateRange = dateRange,
+                    multiDayEvents = listOf(event),
+                    timeRange = TimeSpan.of(LocalTime.of(9, 0), java.time.Duration.ofHours(1)),
+                    weekViewConfig = WeekViewConfig(),
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("MultiDayEventView_4").assertIsNotEnabled()
+    }
+}

--- a/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/EventClickabilityAccessibilityTest.kt
+++ b/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/EventClickabilityAccessibilityTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import de.tobiasschuerg.weekview.data.Event

--- a/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/WeekBackgroundComposeEventDisplayTest.kt
+++ b/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/WeekBackgroundComposeEventDisplayTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.ComposeTestRule
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick

--- a/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/WeekBackgroundComposeEventDisplayTest.kt
+++ b/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/WeekBackgroundComposeEventDisplayTest.kt
@@ -2,10 +2,11 @@ package de.tobiasschuerg.weekview.compose
 
 import androidx.activity.ComponentActivity
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import de.tobiasschuerg.weekview.data.Event
 import de.tobiasschuerg.weekview.data.EventConfig
@@ -23,6 +24,27 @@ import java.time.LocalTime
 class WeekBackgroundComposeEventDisplayTest {
     @get:Rule
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun dayHeaderCanBeClicked() {
+        val firstDay = LocalDate.of(2025, 9, 2)
+        var clickedDate: LocalDate? = null
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                WeekBackgroundCompose(
+                    dateRange = LocalDateRange(firstDay, firstDay.plusDays(2)),
+                    timeRange = TimeSpan.of(LocalTime.of(9, 0), Duration.ofHours(1)),
+                    weekViewConfig = WeekViewConfig(),
+                    onDayClick = { clickedDate = it },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("DayHeader_$firstDay").assertHasClickAction().performClick()
+
+        assert(clickedDate == firstDay)
+    }
 
     @Test
     fun eventIsDisplayedCorrectly() {
@@ -62,7 +84,7 @@ class WeekBackgroundComposeEventDisplayTest {
         composeTestRule.waitForIdle()
 
         // Verify event is displayed with correct test tag
-        composeTestRule.onNodeWithTag("EventView_1").assertIsDisplayed().assert(hasClickAction())
+        composeTestRule.onNodeWithTag("EventView_1").assertIsDisplayed().assertHasClickAction()
     }
 
     @Test

--- a/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/WeekBackgroundComposeEventDisplayTest.kt
+++ b/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/WeekBackgroundComposeEventDisplayTest.kt
@@ -13,6 +13,7 @@ import de.tobiasschuerg.weekview.data.EventConfig
 import de.tobiasschuerg.weekview.data.LocalDateRange
 import de.tobiasschuerg.weekview.data.WeekViewConfig
 import de.tobiasschuerg.weekview.util.TimeSpan
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -43,7 +44,7 @@ class WeekBackgroundComposeEventDisplayTest {
 
         composeTestRule.onNodeWithTag("DayHeader_$firstDay").assertHasClickAction().performClick()
 
-        assert(clickedDate == firstDay)
+        assertEquals(firstDay, clickedDate)
     }
 
     @Test

--- a/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/WeekBackgroundComposeEventDisplayTest.kt
+++ b/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/WeekBackgroundComposeEventDisplayTest.kt
@@ -4,7 +4,9 @@ import androidx.activity.ComponentActivity
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -47,6 +49,17 @@ class WeekBackgroundComposeEventDisplayTest {
         assertEquals(firstDay, clickedDate)
     }
 
+    /**
+     * Waits for the semantics tree to actually publish nodes with the given [tags]
+     * instead of relying on [ComposeTestRule.waitForIdle] alone, which can return
+     * before the freshly recomposed hierarchy is fully published.
+     */
+    private fun ComposeTestRule.waitUntilTagsAreDisplayed(vararg tags: String) {
+        waitUntil(timeoutMillis = 1_000) {
+            tags.all { tag -> onAllNodesWithTag(tag).fetchSemanticsNodes().isNotEmpty() }
+        }
+    }
+
     @Test
     fun eventIsDisplayedCorrectly() {
         // Arrange
@@ -77,12 +90,13 @@ class WeekBackgroundComposeEventDisplayTest {
                         ),
                     timeRange = event.timeSpan,
                     weekViewConfig = WeekViewConfig(),
+                    onEventClick = {},
                 )
             }
         }
 
         // Assert
-        composeTestRule.waitForIdle()
+        composeTestRule.waitUntilTagsAreDisplayed("EventView_1")
 
         // Verify event is displayed with correct test tag
         composeTestRule.onNodeWithTag("EventView_1").assertIsDisplayed().assertHasClickAction()
@@ -123,7 +137,7 @@ class WeekBackgroundComposeEventDisplayTest {
         }
 
         // Assert
-        composeTestRule.waitForIdle()
+        composeTestRule.waitUntilTagsAreDisplayed("EventView_2")
 
         // Verify event is displayed
         composeTestRule.onNodeWithTag("EventView_2").assertIsDisplayed()
@@ -176,7 +190,7 @@ class WeekBackgroundComposeEventDisplayTest {
         }
 
         // Assert
-        composeTestRule.waitForIdle()
+        composeTestRule.waitUntilTagsAreDisplayed("EventView_3", "EventView_4")
 
         // Verify both events are displayed by their tags
         composeTestRule.onNodeWithTag("EventView_3").assertIsDisplayed()
@@ -218,7 +232,7 @@ class WeekBackgroundComposeEventDisplayTest {
         }
 
         // Assert
-        composeTestRule.waitForIdle()
+        composeTestRule.waitUntilTagsAreDisplayed("EventView_5")
 
         // Verify event is displayed with test tag
         composeTestRule.onNodeWithTag("EventView_5").assertIsDisplayed()
@@ -255,7 +269,7 @@ class WeekBackgroundComposeEventDisplayTest {
         }
 
         // Assert
-        composeTestRule.waitForIdle()
+        composeTestRule.waitUntilTagsAreDisplayed("EventView_6")
 
         // Verify event is displayed
         composeTestRule.onNodeWithTag("EventView_6").assertIsDisplayed()

--- a/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/WeekBackgroundComposeEventDisplayTest.kt
+++ b/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/WeekBackgroundComposeEventDisplayTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.ComposeTestRule
-import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick

--- a/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/WeekBackgroundComposeEventDisplayTest.kt
+++ b/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/WeekBackgroundComposeEventDisplayTest.kt
@@ -3,6 +3,7 @@ package de.tobiasschuerg.weekview.compose
 import androidx.activity.ComponentActivity
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -60,11 +61,8 @@ class WeekBackgroundComposeEventDisplayTest {
         // Assert
         composeTestRule.waitForIdle()
 
-        // Wait a bit more to ensure compose hierarchy is fully established
-        Thread.sleep(100)
-
         // Verify event is displayed with correct test tag
-        composeTestRule.onNodeWithTag("EventView_1").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("EventView_1").assertIsDisplayed().assert(hasClickAction())
     }
 
     @Test
@@ -103,7 +101,6 @@ class WeekBackgroundComposeEventDisplayTest {
 
         // Assert
         composeTestRule.waitForIdle()
-        Thread.sleep(100)
 
         // Verify event is displayed
         composeTestRule.onNodeWithTag("EventView_2").assertIsDisplayed()
@@ -157,7 +154,6 @@ class WeekBackgroundComposeEventDisplayTest {
 
         // Assert
         composeTestRule.waitForIdle()
-        Thread.sleep(100)
 
         // Verify both events are displayed by their tags
         composeTestRule.onNodeWithTag("EventView_3").assertIsDisplayed()
@@ -200,7 +196,6 @@ class WeekBackgroundComposeEventDisplayTest {
 
         // Assert
         composeTestRule.waitForIdle()
-        Thread.sleep(100)
 
         // Verify event is displayed with test tag
         composeTestRule.onNodeWithTag("EventView_5").assertIsDisplayed()
@@ -238,7 +233,6 @@ class WeekBackgroundComposeEventDisplayTest {
 
         // Assert
         composeTestRule.waitForIdle()
-        Thread.sleep(100)
 
         // Verify event is displayed
         composeTestRule.onNodeWithTag("EventView_6").assertIsDisplayed()

--- a/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/WeekViewComposeScalingFactorTest.kt
+++ b/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/WeekViewComposeScalingFactorTest.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.unit.dp

--- a/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/WeekViewComposeScalingFactorTest.kt
+++ b/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/WeekViewComposeScalingFactorTest.kt
@@ -1,0 +1,78 @@
+package de.tobiasschuerg.weekview.compose
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import de.tobiasschuerg.weekview.data.LocalDateRange
+import de.tobiasschuerg.weekview.data.WeekData
+import de.tobiasschuerg.weekview.data.WeekViewConfig
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.time.LocalDate
+import java.time.LocalTime
+
+@RunWith(AndroidJUnit4::class)
+class WeekViewComposeScalingFactorTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    /**
+     * Reproduces the crash where a persisted (unsynced) zoom level falls outside a
+     * subsequently tightened [WeekViewConfig.minScalingFactor]/[WeekViewConfig.maxScalingFactor],
+     * causing [WeekViewConfig]'s own `require` check to throw when `WeekViewCompose` rebuilds its
+     * active config from the raw persisted scaling factor.
+     */
+    @Test
+    fun doesNotCrashWhenScalingBoundsTightenAfterZoom() {
+        val today = LocalDate.of(2025, 9, 2)
+        val weekData = WeekData(LocalDateRange(today, today), LocalTime.of(8, 0), LocalTime.of(18, 0))
+        var config by mutableStateOf(
+            WeekViewConfig(scalingFactor = 1f, minScalingFactor = 0.5f, maxScalingFactor = 2f),
+        )
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                WeekViewCompose(
+                    weekData = weekData,
+                    weekViewConfig = config,
+                    modifier = Modifier.testTag("WeekView").size(300.dp, 600.dp),
+                )
+            }
+        }
+
+        // Pinch in to drive the persisted zoom state down to the current minimum (0.5f).
+        composeTestRule.onNodeWithTag("WeekView").performTouchInput {
+            val p1Start = Offset(center.x - 100f, center.y)
+            val p2Start = Offset(center.x + 100f, center.y)
+            down(1, p1Start)
+            down(2, p2Start)
+            updatePointerTo(1, Offset(center.x - 10f, center.y))
+            updatePointerTo(2, Offset(center.x + 10f, center.y))
+            move()
+            up(1)
+            up(2)
+        }
+        composeTestRule.waitForIdle()
+
+        // Tighten minScalingFactor without changing weekViewConfig.scalingFactor, so the
+        // stale persisted zoom state (0.5f) is never resynced before the next recomposition.
+        config = config.copy(minScalingFactor = 0.9f)
+        composeTestRule.waitForIdle()
+
+        // Should recompose without WeekViewConfig's init `require` throwing.
+        composeTestRule.onNodeWithTag("WeekView").assertIsDisplayed()
+    }
+}

--- a/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/WeekViewComposeScalingFactorTest.kt
+++ b/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/WeekViewComposeScalingFactorTest.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.unit.dp

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/EventCompose.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/EventCompose.kt
@@ -1,7 +1,7 @@
 package de.tobiasschuerg.weekview.compose
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -18,9 +18,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -93,11 +95,14 @@ fun EventCompose(
                 .let { if (eventConfig.eventSpacingDp > 0) it.padding(eventConfig.eventSpacingDp.dp) else it }
                 .clip(RoundedCornerShape(cornerRadius))
                 .background(backgroundColor)
-                .pointerInput(event.id) {
-                    detectTapGestures(
-                        onTap = { onEventClick?.invoke(event) },
-                        onLongPress = { onEventLongPress?.invoke(event) },
-                    )
+                .combinedClickable(
+                    role = Role.Button,
+                    onClick = { onEventClick?.invoke(event) },
+                    onLongClick = onEventLongPress?.let { { it(event) } },
+                )
+                .semantics {
+                    contentDescription =
+                        "${event.title}, ${event.timeSpan.start.toLocalString()} - ${event.timeSpan.endExclusive.toLocalString()}"
                 }
                 .padding(start = 4.dp, top = 4.dp, end = 4.dp),
     ) {

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/EventCompose.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/EventCompose.kt
@@ -39,6 +39,7 @@ import de.tobiasschuerg.weekview.util.toLocalString
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalTime
+import java.util.Locale
 
 /**
  * Composable that renders individual events on the week view grid.
@@ -53,6 +54,7 @@ fun EventCompose(
     startTime: LocalTime,
     columnWidth: Dp,
     eventLayout: EventOverlapCalculator.EventLayout,
+    locale: Locale = Locale.getDefault(),
     onEventClick: ((event: Event) -> Unit)? = null,
     onEventLongPress: ((event: Event) -> Unit)? = null,
 ) {
@@ -96,13 +98,15 @@ fun EventCompose(
                 .clip(RoundedCornerShape(cornerRadius))
                 .background(backgroundColor)
                 .combinedClickable(
+                    enabled = onEventClick != null || onEventLongPress != null,
                     role = Role.Button,
                     onClick = { onEventClick?.invoke(event) },
                     onLongClick = onEventLongPress?.let { { it(event) } },
                 )
                 .semantics {
                     contentDescription =
-                        "${event.title}, ${event.timeSpan.start.toLocalString()} - ${event.timeSpan.endExclusive.toLocalString()}"
+                        "${event.title}, ${event.timeSpan.start.toLocalString(locale)} - " +
+                        event.timeSpan.endExclusive.toLocalString(locale)
                 }
                 .padding(start = 4.dp, top = 4.dp, end = 4.dp),
     ) {
@@ -139,7 +143,7 @@ fun EventCompose(
 
             // Time information (if enabled)
             if (eventConfig.showTimeEnd) {
-                val timeText = "${event.timeSpan.start.toLocalString()} - ${event.timeSpan.endExclusive.toLocalString()}"
+                val timeText = "${event.timeSpan.start.toLocalString(locale)} - ${event.timeSpan.endExclusive.toLocalString(locale)}"
 
                 Text(
                     text = timeText,

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/EventsWithOverlapHandling.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/EventsWithOverlapHandling.kt
@@ -2,6 +2,8 @@ package de.tobiasschuerg.weekview.compose
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import de.tobiasschuerg.weekview.data.Event
@@ -27,30 +29,37 @@ fun EventsWithOverlapHandling(
 ) {
     // Filter events for the current day and time range
     val visibleEvents =
-        events.filter { event ->
-            // Check if event is within the visible time range
-            event.timeSpan.start < endTime && event.timeSpan.endExclusive > startTime
+        remember(events, startTime, endTime) {
+            events.filter { event ->
+                // Check if event is within the visible time range
+                event.timeSpan.start < endTime && event.timeSpan.endExclusive > startTime
+            }
         }
 
     if (visibleEvents.isEmpty()) return
 
     // Calculate overlap layouts for all visible events
-    val eventLayouts = EventOverlapCalculator.calculateEventLayouts(visibleEvents)
+    val eventLayouts =
+        remember(visibleEvents) {
+            EventOverlapCalculator.calculateEventLayouts(visibleEvents)
+        }
 
     Box(modifier = modifier) {
         visibleEvents.forEach { event ->
-            val layout: EventOverlapCalculator.EventLayout? = eventLayouts[event.id]
-            if (layout != null) {
-                EventCompose(
-                    event = event,
-                    scalingFactor = scalingFactor,
-                    eventConfig = eventConfig,
-                    startTime = startTime,
-                    columnWidth = columnWidth,
-                    eventLayout = layout,
-                    onEventClick = onEventClick,
-                    onEventLongPress = onEventLongPress,
-                )
+            key(event.id) {
+                val layout: EventOverlapCalculator.EventLayout? = eventLayouts[event.id]
+                if (layout != null) {
+                    EventCompose(
+                        event = event,
+                        scalingFactor = scalingFactor,
+                        eventConfig = eventConfig,
+                        startTime = startTime,
+                        columnWidth = columnWidth,
+                        eventLayout = layout,
+                        onEventClick = onEventClick,
+                        onEventLongPress = onEventLongPress,
+                    )
+                }
             }
         }
     }

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/EventsWithOverlapHandling.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/EventsWithOverlapHandling.kt
@@ -10,6 +10,7 @@ import de.tobiasschuerg.weekview.data.Event
 import de.tobiasschuerg.weekview.data.EventConfig
 import de.tobiasschuerg.weekview.util.EventOverlapCalculator
 import java.time.LocalTime
+import java.util.Locale
 
 /**
  * Composable for rendering multiple events with overlap handling.
@@ -24,6 +25,7 @@ fun EventsWithOverlapHandling(
     startTime: LocalTime,
     endTime: LocalTime,
     columnWidth: Dp,
+    locale: Locale = Locale.getDefault(),
     onEventClick: ((event: Event) -> Unit)? = null,
     onEventLongPress: ((event: Event) -> Unit)? = null,
 ) {
@@ -56,6 +58,7 @@ fun EventsWithOverlapHandling(
                         startTime = startTime,
                         columnWidth = columnWidth,
                         eventLayout = layout,
+                        locale = locale,
                         onEventClick = onEventClick,
                         onEventLongPress = onEventLongPress,
                     )

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/WeekBackgroundCompose.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/WeekBackgroundCompose.kt
@@ -1,5 +1,6 @@
 package de.tobiasschuerg.weekview.compose
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -51,16 +52,19 @@ fun WeekBackgroundCompose(
     onEventClick: ((event: Event) -> Unit)? = null,
     onEventLongPress: ((event: Event) -> Unit)? = null,
     style: WeekViewStyle = defaultWeekViewStyle(),
+    scrollState: ScrollState = rememberScrollState(),
 ) {
     val metrics = rememberWeekViewMetrics(dateRange, timeRange, events, weekViewConfig.scalingFactor)
-    val scrollState = rememberScrollState()
     val today = LocalDate.now()
     var now by remember { mutableStateOf(LocalTime.now()) }
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(weekViewConfig.showCurrentTimeIndicator) {
+        if (!weekViewConfig.showCurrentTimeIndicator) return@LaunchedEffect
+
         while (true) {
             now = LocalTime.now()
-            delay(1000)
+            val millisUntilNextMinute = 60_000L - (System.currentTimeMillis() % 60_000L)
+            delay(millisUntilNextMinute)
         }
     }
 

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/WeekBackgroundCompose.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/WeekBackgroundCompose.kt
@@ -51,19 +51,23 @@ fun WeekBackgroundCompose(
     weekViewConfig: WeekViewConfig,
     onEventClick: ((event: Event) -> Unit)? = null,
     onEventLongPress: ((event: Event) -> Unit)? = null,
-    onDayClick: ((date: LocalDate) -> Unit)? = null,
     style: WeekViewStyle = defaultWeekViewStyle(),
     scrollState: ScrollState = rememberScrollState(),
+    onDayClick: ((date: LocalDate) -> Unit)? = null,
 ) {
     val metrics = rememberWeekViewMetrics(dateRange, timeRange, events, weekViewConfig.scalingFactor)
-    val today = LocalDate.now()
+    var today by remember { mutableStateOf(LocalDate.now()) }
     var now by remember { mutableStateOf(LocalTime.now()) }
 
-    LaunchedEffect(weekViewConfig.showCurrentTimeIndicator) {
-        if (!weekViewConfig.showCurrentTimeIndicator) return@LaunchedEffect
+    LaunchedEffect(weekViewConfig.showCurrentTimeIndicator, weekViewConfig.highlightCurrentDay) {
+        if (!weekViewConfig.showCurrentTimeIndicator && !weekViewConfig.highlightCurrentDay) return@LaunchedEffect
 
         while (true) {
-            now = LocalTime.now()
+            val currentDateTime = java.time.LocalDateTime.now()
+            today = currentDateTime.toLocalDate()
+            if (weekViewConfig.showCurrentTimeIndicator) {
+                now = currentDateTime.toLocalTime()
+            }
             val millisUntilNextMinute = 60_000L - (System.currentTimeMillis() % 60_000L)
             delay(millisUntilNextMinute)
         }

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/WeekBackgroundCompose.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/WeekBackgroundCompose.kt
@@ -51,6 +51,7 @@ fun WeekBackgroundCompose(
     weekViewConfig: WeekViewConfig,
     onEventClick: ((event: Event) -> Unit)? = null,
     onEventLongPress: ((event: Event) -> Unit)? = null,
+    onDayClick: ((date: LocalDate) -> Unit)? = null,
     style: WeekViewStyle = defaultWeekViewStyle(),
     scrollState: ScrollState = rememberScrollState(),
 ) {
@@ -82,6 +83,7 @@ fun WeekBackgroundCompose(
                 style = style,
                 highlightCurrentDay = weekViewConfig.highlightCurrentDay,
                 eventConfig = eventConfig,
+                onDayClick = onDayClick,
             )
 
             if (multiDayEvents.isNotEmpty()) {

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/WeekBackgroundCompose.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/WeekBackgroundCompose.kt
@@ -55,7 +55,13 @@ fun WeekBackgroundCompose(
     scrollState: ScrollState = rememberScrollState(),
     onDayClick: ((date: LocalDate) -> Unit)? = null,
 ) {
-    val metrics = rememberWeekViewMetrics(dateRange, timeRange, events, weekViewConfig.scalingFactor)
+    val metrics =
+        rememberWeekViewMetrics(
+            dateRange = dateRange,
+            timeRange = timeRange,
+            events = events,
+            scalingFactor = weekViewConfig.scalingFactor,
+        )
     var today by remember { mutableStateOf(LocalDate.now()) }
     var now by remember { mutableStateOf(LocalTime.now()) }
 
@@ -87,6 +93,7 @@ fun WeekBackgroundCompose(
                 style = style,
                 highlightCurrentDay = weekViewConfig.highlightCurrentDay,
                 eventConfig = eventConfig,
+                locale = weekViewConfig.locale,
                 onDayClick = onDayClick,
             )
 

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/WeekBackgroundCompose.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/WeekBackgroundCompose.kt
@@ -167,6 +167,7 @@ fun WeekBackgroundCompose(
                         gridStartTime = metrics.gridStartTime,
                         effectiveEndTime = metrics.effectiveEndTime,
                         scalingFactor = weekViewConfig.scalingFactor,
+                        locale = weekViewConfig.locale,
                         style = style,
                     )
                 }

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/WeekViewActions.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/WeekViewActions.kt
@@ -1,6 +1,7 @@
 package de.tobiasschuerg.weekview.compose
 
 import de.tobiasschuerg.weekview.data.Event
+import java.time.LocalDate
 
 /**
  * Grouped callbacks for the Compose WeekView API.
@@ -9,5 +10,6 @@ import de.tobiasschuerg.weekview.data.Event
 data class WeekViewActions(
     val onEventClick: ((event: Event) -> Unit)? = null,
     val onEventLongPress: ((event: Event) -> Unit)? = null,
+    val onDayClick: ((date: LocalDate) -> Unit)? = null,
     val onScalingFactorChange: ((Float) -> Unit)? = null,
 )

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/WeekViewActions.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/WeekViewActions.kt
@@ -10,6 +10,6 @@ import java.time.LocalDate
 data class WeekViewActions(
     val onEventClick: ((event: Event) -> Unit)? = null,
     val onEventLongPress: ((event: Event) -> Unit)? = null,
-    val onDayClick: ((date: LocalDate) -> Unit)? = null,
     val onScalingFactorChange: ((Float) -> Unit)? = null,
+    val onDayClick: ((date: LocalDate) -> Unit)? = null,
 )

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/WeekViewCompose.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/WeekViewCompose.kt
@@ -81,6 +81,7 @@ fun WeekViewCompose(
             eventConfig = eventConfig,
             onEventClick = actions.onEventClick,
             onEventLongPress = actions.onEventLongPress,
+            onDayClick = actions.onDayClick,
             weekViewConfig = activeWeekConfig,
             scrollState = state.scrollState,
         )

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/WeekViewCompose.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/WeekViewCompose.kt
@@ -40,7 +40,9 @@ fun WeekViewCompose(
     LaunchedEffect(weekViewConfig.scalingFactor) {
         state.syncConfiguredScalingFactor(weekViewConfig.scalingFactor)
     }
-    val activeWeekConfig = weekViewConfig.copy(scalingFactor = state.scalingFactor)
+    val clampedScalingFactor =
+        state.scalingFactor.coerceIn(weekViewConfig.minScalingFactor, weekViewConfig.maxScalingFactor)
+    val activeWeekConfig = weekViewConfig.copy(scalingFactor = clampedScalingFactor)
 
     Box(
         modifier =

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/WeekViewCompose.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/WeekViewCompose.kt
@@ -36,6 +36,7 @@ fun WeekViewCompose(
     actions: WeekViewActions = WeekViewActions(),
     state: WeekViewState = rememberWeekViewState(weekViewConfig.scalingFactor),
 ) {
+    weekData.changeVersion
     LaunchedEffect(weekViewConfig.scalingFactor) {
         state.syncConfiguredScalingFactor(weekViewConfig.scalingFactor)
     }

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/WeekViewCompose.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/WeekViewCompose.kt
@@ -6,12 +6,12 @@ import androidx.compose.foundation.gestures.calculateZoom
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
+import de.tobiasschuerg.weekview.compose.state.WeekViewState
+import de.tobiasschuerg.weekview.compose.state.rememberWeekViewState
 import de.tobiasschuerg.weekview.data.EventConfig
 import de.tobiasschuerg.weekview.data.WeekData
 import de.tobiasschuerg.weekview.data.WeekViewConfig
@@ -34,14 +34,17 @@ fun WeekViewCompose(
     modifier: Modifier = Modifier,
     eventConfig: EventConfig = EventConfig(),
     actions: WeekViewActions = WeekViewActions(),
+    state: WeekViewState = rememberWeekViewState(weekViewConfig.scalingFactor),
 ) {
-    var localScalingFactor by remember { mutableFloatStateOf(weekViewConfig.scalingFactor) }
-    val activeWeekConfig = weekViewConfig.copy(scalingFactor = localScalingFactor)
+    LaunchedEffect(weekViewConfig.scalingFactor) {
+        state.syncConfiguredScalingFactor(weekViewConfig.scalingFactor)
+    }
+    val activeWeekConfig = weekViewConfig.copy(scalingFactor = state.scalingFactor)
 
     Box(
         modifier =
             modifier
-                .pointerInput(Unit) {
+                .pointerInput(weekViewConfig.minScalingFactor, weekViewConfig.maxScalingFactor) {
                     awaitEachGesture {
                         awaitFirstDown(requireUnconsumed = false)
                         do {
@@ -49,14 +52,11 @@ fun WeekViewCompose(
                             if (event.changes.size >= 2) {
                                 val zoom = event.calculateZoom()
                                 if (zoom != 1f) {
-                                    val newScalingFactor =
-                                        (localScalingFactor * zoom)
-                                            .coerceIn(
-                                                activeWeekConfig.minScalingFactor,
-                                                activeWeekConfig.maxScalingFactor,
-                                            )
-                                    if (newScalingFactor != localScalingFactor) {
-                                        localScalingFactor = newScalingFactor
+                                    state.applyZoom(
+                                        zoom = zoom,
+                                        minScalingFactor = weekViewConfig.minScalingFactor,
+                                        maxScalingFactor = weekViewConfig.maxScalingFactor,
+                                    )?.let { newScalingFactor ->
                                         actions.onScalingFactorChange?.invoke(newScalingFactor)
                                     }
                                     event.changes.forEach { it.consume() }
@@ -82,6 +82,7 @@ fun WeekViewCompose(
             onEventClick = actions.onEventClick,
             onEventLongPress = actions.onEventLongPress,
             weekViewConfig = activeWeekConfig,
+            scrollState = state.scrollState,
         )
     }
 }

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/components/AllDayEventsRow.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/components/AllDayEventsRow.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -40,36 +41,40 @@ internal fun AllDayEventsRow(
         Spacer(modifier = Modifier.width(leftOffsetDp))
         days.forEach { date ->
             val eventsForDay = allDayEvents.filter { it.date == date }
-            Column(
-                modifier = Modifier.width(columnWidth).padding(horizontal = 1.dp),
-            ) {
-                eventsForDay.forEach { event ->
-                    Box(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .height(24.dp)
-                                .padding(vertical = 1.dp)
-                                .clip(RoundedCornerShape(4.dp))
-                                .background(Color(event.backgroundColor))
-                                .combinedClickable(
-                                    role = Role.Button,
-                                    onClick = { onEventClick?.invoke(event) },
-                                    onLongClick = onEventLongPress?.let { { it(event) } },
+            key(date) {
+                Column(
+                    modifier = Modifier.width(columnWidth).padding(horizontal = 1.dp),
+                ) {
+                    eventsForDay.forEach { event ->
+                        key(event.id) {
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .height(24.dp)
+                                        .padding(vertical = 1.dp)
+                                        .clip(RoundedCornerShape(4.dp))
+                                        .background(Color(event.backgroundColor))
+                                        .combinedClickable(
+                                            role = Role.Button,
+                                            onClick = { onEventClick?.invoke(event) },
+                                            onLongClick = onEventLongPress?.let { { it(event) } },
+                                        )
+                                        .semantics {
+                                            contentDescription = "${event.title}, all day"
+                                        }
+                                        .padding(horizontal = 4.dp),
+                                contentAlignment = Alignment.CenterStart,
+                            ) {
+                                Text(
+                                    text = event.title,
+                                    color = Color(event.textColor),
+                                    fontSize = 11.sp,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
                                 )
-                                .semantics {
-                                    contentDescription = "${event.title}, all day"
-                                }
-                                .padding(horizontal = 4.dp),
-                        contentAlignment = Alignment.CenterStart,
-                    ) {
-                        Text(
-                            text = event.title,
-                            color = Color(event.textColor),
-                            fontSize = 11.sp,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
+                            }
+                        }
                     }
                 }
             }

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/components/AllDayEventsRow.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/components/AllDayEventsRow.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -50,12 +51,14 @@ internal fun AllDayEventsRow(
                             Box(
                                 modifier =
                                     Modifier
+                                        .testTag("AllDayEventView_${event.id}")
                                         .fillMaxWidth()
                                         .height(24.dp)
                                         .padding(vertical = 1.dp)
                                         .clip(RoundedCornerShape(4.dp))
                                         .background(Color(event.backgroundColor))
                                         .combinedClickable(
+                                            enabled = onEventClick != null || onEventLongPress != null,
                                             role = Role.Button,
                                             onClick = { onEventClick?.invoke(event) },
                                             onLongClick = onEventLongPress?.let { { it(event) } },

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/components/AllDayEventsRow.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/components/AllDayEventsRow.kt
@@ -1,7 +1,7 @@
 package de.tobiasschuerg.weekview.compose.components
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -17,7 +17,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -50,11 +52,13 @@ internal fun AllDayEventsRow(
                                 .padding(vertical = 1.dp)
                                 .clip(RoundedCornerShape(4.dp))
                                 .background(Color(event.backgroundColor))
-                                .pointerInput(event.id) {
-                                    detectTapGestures(
-                                        onTap = { onEventClick?.invoke(event) },
-                                        onLongPress = { onEventLongPress?.invoke(event) },
-                                    )
+                                .combinedClickable(
+                                    role = Role.Button,
+                                    onClick = { onEventClick?.invoke(event) },
+                                    onLongClick = onEventLongPress?.let { { it(event) } },
+                                )
+                                .semantics {
+                                    contentDescription = "${event.title}, all day"
                                 }
                                 .padding(horizontal = 4.dp),
                         contentAlignment = Alignment.CenterStart,

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/components/DayHeaderRow.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/components/DayHeaderRow.kt
@@ -42,6 +42,7 @@ internal fun DayHeaderRow(
     style: WeekViewStyle = defaultWeekViewStyle(),
     highlightCurrentDay: Boolean = true,
     eventConfig: EventConfig = EventConfig(),
+    locale: Locale = Locale.getDefault(),
     onDayClick: ((date: LocalDate) -> Unit)? = null,
 ) {
     val locale = LocalLocale.current.platformLocale

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/components/DayHeaderRow.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/components/DayHeaderRow.kt
@@ -1,6 +1,7 @@
 package de.tobiasschuerg.weekview.compose.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -12,6 +13,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLocale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -37,6 +42,7 @@ internal fun DayHeaderRow(
     style: WeekViewStyle = defaultWeekViewStyle(),
     highlightCurrentDay: Boolean = true,
     eventConfig: EventConfig = EventConfig(),
+    onDayClick: ((date: LocalDate) -> Unit)? = null,
 ) {
     val locale = LocalLocale.current.platformLocale
 
@@ -79,7 +85,17 @@ internal fun DayHeaderRow(
                 }
             val shortDate = date.toShortDateStringWithoutYear(locale)
             Column(
-                modifier = boxModifier,
+                modifier =
+                    boxModifier
+                        .testTag("DayHeader_$date")
+                        .semantics {
+                            contentDescription = "$dayName, $shortDate"
+                        }
+                        .combinedClickable(
+                            enabled = onDayClick != null,
+                            role = Role.Button,
+                            onClick = { onDayClick?.invoke(date) },
+                        ),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Text(

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/components/DayHeaderRow.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/components/DayHeaderRow.kt
@@ -31,6 +31,7 @@ import de.tobiasschuerg.weekview.util.toShortDateStringWithoutYear
 import java.time.LocalDate
 import java.time.format.TextStyle.FULL
 import java.time.format.TextStyle.SHORT
+import java.util.Locale
 
 @Composable
 internal fun DayHeaderRow(
@@ -42,11 +43,9 @@ internal fun DayHeaderRow(
     style: WeekViewStyle = defaultWeekViewStyle(),
     highlightCurrentDay: Boolean = true,
     eventConfig: EventConfig = EventConfig(),
-    locale: Locale = Locale.getDefault(),
+    locale: Locale = LocalLocale.current.platformLocale,
     onDayClick: ((date: LocalDate) -> Unit)? = null,
 ) {
-    val locale = LocalLocale.current.platformLocale
-
     Row {
         Box(modifier = Modifier.size(leftOffsetDp, topOffsetDp))
         days.forEach { date ->

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/components/EventsPane.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/components/EventsPane.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.times
@@ -29,27 +31,29 @@ internal fun EventsPane(
     scalingFactor: Float,
     style: WeekViewStyle = defaultWeekViewStyle(),
 ) {
+    val eventsByDate = remember(events) { events.groupBy { it.date } }
+
     days.forEachIndexed { dayIndex, date ->
-        val eventsForDay = events.filter { it.date == date }
+        val eventsForDay = eventsByDate[date].orEmpty()
         if (eventsForDay.isNotEmpty()) {
-            Box(
-                modifier =
-                    Modifier
-                        .offset(x = dayIndex * columnWidth)
-                        .size(columnWidth, gridHeightDp),
-                // Height must be total grid height for proper event positioning
-            ) {
-                EventsWithOverlapHandling(
-                    events = eventsForDay,
-                    scalingFactor = scalingFactor,
-                    eventConfig = eventConfig,
-                    startTime = gridStartTime,
-                    endTime = effectiveEndTime,
-                    columnWidth = columnWidth,
-                    onEventClick = onEventClick,
-                    onEventLongPress = onEventLongPress,
-                    // style = style // Pass style to EventsWithOverlapHandling if it needs it in the future
-                )
+            key(date) {
+                Box(
+                    modifier =
+                        Modifier
+                            .offset(x = dayIndex * columnWidth)
+                            .size(columnWidth, gridHeightDp),
+                ) {
+                    EventsWithOverlapHandling(
+                        events = eventsForDay,
+                        scalingFactor = scalingFactor,
+                        eventConfig = eventConfig,
+                        startTime = gridStartTime,
+                        endTime = effectiveEndTime,
+                        columnWidth = columnWidth,
+                        onEventClick = onEventClick,
+                        onEventLongPress = onEventLongPress,
+                    )
+                }
             }
         }
     }

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/components/EventsPane.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/components/EventsPane.kt
@@ -16,6 +16,7 @@ import de.tobiasschuerg.weekview.data.Event
 import de.tobiasschuerg.weekview.data.EventConfig
 import java.time.LocalDate
 import java.time.LocalTime
+import java.util.Locale
 
 @Composable
 internal fun EventsPane(
@@ -29,6 +30,7 @@ internal fun EventsPane(
     gridStartTime: LocalTime,
     effectiveEndTime: LocalTime,
     scalingFactor: Float,
+    locale: Locale = Locale.getDefault(),
     style: WeekViewStyle = defaultWeekViewStyle(),
 ) {
     val eventsByDate = remember(events) { events.groupBy { it.date } }
@@ -50,6 +52,7 @@ internal fun EventsPane(
                         startTime = gridStartTime,
                         endTime = effectiveEndTime,
                         columnWidth = columnWidth,
+                        locale = locale,
                         onEventClick = onEventClick,
                         onEventLongPress = onEventLongPress,
                     )

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/components/MultiDayEventsRow.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/components/MultiDayEventsRow.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -64,6 +65,7 @@ internal fun MultiDayEventsRow(
                             Box(
                                 modifier =
                                     Modifier
+                                        .testTag("MultiDayEventView_${event.id}")
                                         .offset(x = leftOffsetDp + columnWidth * startIndex)
                                         .width(columnWidth * spanDays)
                                         .height(24.dp)
@@ -71,6 +73,7 @@ internal fun MultiDayEventsRow(
                                         .clip(RoundedCornerShape(4.dp))
                                         .background(Color(event.backgroundColor))
                                         .combinedClickable(
+                                            enabled = onEventClick != null || onEventLongPress != null,
                                             role = Role.Button,
                                             onClick = { onEventClick?.invoke(event) },
                                             onLongClick = onEventLongPress?.let { { it(event) } },

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/components/MultiDayEventsRow.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/components/MultiDayEventsRow.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -45,46 +46,50 @@ internal fun MultiDayEventsRow(
     val rows = packEventsIntoRows(multiDayEvents, firstDay, lastDay)
 
     Column(modifier = Modifier.fillMaxWidth()) {
-        rows.forEach { row ->
-            Box(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .height(24.dp),
-            ) {
-                row.forEach { event ->
-                    val clippedStart = maxOf(event.date, firstDay)
-                    val clippedEnd = minOf(event.lastDate, lastDay)
-                    val startIndex = ChronoUnit.DAYS.between(firstDay, clippedStart).toInt()
-                    val spanDays = ChronoUnit.DAYS.between(clippedStart, clippedEnd).toInt() + 1
+        rows.forEachIndexed { rowIndex, row ->
+            key(rowIndex) {
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(24.dp),
+                ) {
+                    row.forEach { event ->
+                        key(event.id) {
+                            val clippedStart = maxOf(event.date, firstDay)
+                            val clippedEnd = minOf(event.lastDate, lastDay)
+                            val startIndex = ChronoUnit.DAYS.between(firstDay, clippedStart).toInt()
+                            val spanDays = ChronoUnit.DAYS.between(clippedStart, clippedEnd).toInt() + 1
 
-                    Box(
-                        modifier =
-                            Modifier
-                                .offset(x = leftOffsetDp + columnWidth * startIndex)
-                                .width(columnWidth * spanDays)
-                                .height(24.dp)
-                                .padding(horizontal = 1.dp, vertical = 1.dp)
-                                .clip(RoundedCornerShape(4.dp))
-                                .background(Color(event.backgroundColor))
-                                .combinedClickable(
-                                    role = Role.Button,
-                                    onClick = { onEventClick?.invoke(event) },
-                                    onLongClick = onEventLongPress?.let { { it(event) } },
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .offset(x = leftOffsetDp + columnWidth * startIndex)
+                                        .width(columnWidth * spanDays)
+                                        .height(24.dp)
+                                        .padding(horizontal = 1.dp, vertical = 1.dp)
+                                        .clip(RoundedCornerShape(4.dp))
+                                        .background(Color(event.backgroundColor))
+                                        .combinedClickable(
+                                            role = Role.Button,
+                                            onClick = { onEventClick?.invoke(event) },
+                                            onLongClick = onEventLongPress?.let { { it(event) } },
+                                        )
+                                        .semantics {
+                                            contentDescription = "${event.title}, ${event.date} to ${event.lastDate}"
+                                        }
+                                        .padding(horizontal = 4.dp),
+                                contentAlignment = Alignment.CenterStart,
+                            ) {
+                                Text(
+                                    text = event.title,
+                                    color = Color(event.textColor),
+                                    fontSize = 11.sp,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
                                 )
-                                .semantics {
-                                    contentDescription = "${event.title}, ${event.date} to ${event.lastDate}"
-                                }
-                                .padding(horizontal = 4.dp),
-                        contentAlignment = Alignment.CenterStart,
-                    ) {
-                        Text(
-                            text = event.title,
-                            color = Color(event.textColor),
-                            fontSize = 11.sp,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
+                            }
+                        }
                     }
                 }
             }

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/components/MultiDayEventsRow.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/components/MultiDayEventsRow.kt
@@ -1,7 +1,7 @@
 package de.tobiasschuerg.weekview.compose.components
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -16,7 +16,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -65,11 +67,13 @@ internal fun MultiDayEventsRow(
                                 .padding(horizontal = 1.dp, vertical = 1.dp)
                                 .clip(RoundedCornerShape(4.dp))
                                 .background(Color(event.backgroundColor))
-                                .pointerInput(event.id) {
-                                    detectTapGestures(
-                                        onTap = { onEventClick?.invoke(event) },
-                                        onLongPress = { onEventLongPress?.invoke(event) },
-                                    )
+                                .combinedClickable(
+                                    role = Role.Button,
+                                    onClick = { onEventClick?.invoke(event) },
+                                    onLongClick = onEventLongPress?.let { { it(event) } },
+                                )
+                                .semantics {
+                                    contentDescription = "${event.title}, ${event.date} to ${event.lastDate}"
                                 }
                                 .padding(horizontal = 4.dp),
                         contentAlignment = Alignment.CenterStart,

--- a/library/src/main/java/de/tobiasschuerg/weekview/compose/state/WeekViewState.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/compose/state/WeekViewState.kt
@@ -1,0 +1,51 @@
+package de.tobiasschuerg.weekview.compose.state
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+
+@Stable
+class WeekViewState internal constructor(
+    initialScalingFactor: Float,
+    val scrollState: ScrollState,
+) {
+    var scalingFactor by mutableFloatStateOf(initialScalingFactor)
+        private set
+
+    private var lastConfiguredScalingFactor by mutableFloatStateOf(initialScalingFactor)
+
+    internal fun syncConfiguredScalingFactor(configuredScalingFactor: Float) {
+        if (configuredScalingFactor != lastConfiguredScalingFactor) {
+            scalingFactor = configuredScalingFactor
+            lastConfiguredScalingFactor = configuredScalingFactor
+        }
+    }
+
+    internal fun applyZoom(
+        zoom: Float,
+        minScalingFactor: Float,
+        maxScalingFactor: Float,
+    ): Float? {
+        val newScalingFactor = (scalingFactor * zoom).coerceIn(minScalingFactor, maxScalingFactor)
+        if (newScalingFactor == scalingFactor) return null
+
+        scalingFactor = newScalingFactor
+        return newScalingFactor
+    }
+}
+
+@Composable
+fun rememberWeekViewState(initialScalingFactor: Float = 1f): WeekViewState {
+    val scrollState = rememberScrollState()
+    return remember {
+        WeekViewState(
+            initialScalingFactor = initialScalingFactor,
+            scrollState = scrollState,
+        )
+    }
+}

--- a/library/src/main/java/de/tobiasschuerg/weekview/data/WeekData.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/data/WeekData.kt
@@ -1,5 +1,6 @@
 package de.tobiasschuerg.weekview.data
 
+import androidx.compose.runtime.mutableIntStateOf
 import de.tobiasschuerg.weekview.util.TimeSpan
 import java.time.LocalTime
 
@@ -15,8 +16,13 @@ class WeekData(
     private val singleEvents: MutableList<Event.Single> = mutableListOf()
     private val allDays: MutableList<Event.AllDay> = mutableListOf()
     private val multiDayEvents: MutableList<Event.MultiDay> = mutableListOf()
+    private val eventIds: MutableSet<Long> = mutableSetOf()
+    private val changeVersionState = mutableIntStateOf(0)
     private var earliestStart: LocalTime = start
     private var latestEnd: LocalTime = end
+
+    internal val changeVersion: Int
+        get() = changeVersionState.intValue
 
     fun getTimeSpan(): TimeSpan? {
         val start = earliestStart
@@ -27,21 +33,35 @@ class WeekData(
 
     fun add(item: Event.AllDay) {
         require(dateRange.contains(item.date)) { "Event date is outside the allowed range: ${item.date}" }
+        requireUniqueId(item)
         allDays.add(item)
+        markChanged()
     }
 
     fun add(item: Event.MultiDay) {
         val overlaps = item.date <= dateRange.endInclusive && item.lastDate >= dateRange.start
         require(overlaps) { "MultiDay event (${item.date}..${item.lastDate}) does not overlap with the allowed range: $dateRange" }
+        requireUniqueId(item)
         multiDayEvents.add(item)
+        markChanged()
     }
 
     fun add(item: Event.Single) {
         require(dateRange.contains(item.date)) { "Event date ${item.date} is outside the allowed range: $dateRange" }
+        requireUniqueId(item)
         singleEvents.add(item)
 
         // Automatically adjust TimeSpan to accommodate the new event
         updateTimeSpanForEvent(item)
+        markChanged()
+    }
+
+    private fun requireUniqueId(event: Event) {
+        require(eventIds.add(event.id)) { "Event ID must be unique, but ${event.id} is already in use" }
+    }
+
+    private fun markChanged() {
+        changeVersionState.intValue++
     }
 
     /**
@@ -76,7 +96,9 @@ class WeekData(
         singleEvents.clear()
         allDays.clear()
         multiDayEvents.clear()
+        eventIds.clear()
         earliestStart = start
         latestEnd = end
+        markChanged()
     }
 }

--- a/library/src/main/java/de/tobiasschuerg/weekview/data/WeekViewConfig.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/data/WeekViewConfig.kt
@@ -1,5 +1,7 @@
 package de.tobiasschuerg.weekview.data
 
+import java.util.Locale
+
 data class WeekViewConfig(
     val scalingFactor: Float = 1f,
     val minScalingFactor: Float = 0.5f,
@@ -7,6 +9,7 @@ data class WeekViewConfig(
     val showCurrentTimeIndicator: Boolean = true,
     val highlightCurrentDay: Boolean = true,
     val currentTimeLineOnlyToday: Boolean = false,
+    val locale: Locale = Locale.getDefault(),
 ) {
     init {
         require(minScalingFactor > 0f) { "minScalingFactor must be positive, but was $minScalingFactor" }

--- a/library/src/main/java/de/tobiasschuerg/weekview/data/WeekViewConfig.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/data/WeekViewConfig.kt
@@ -13,5 +13,8 @@ data class WeekViewConfig(
         require(minScalingFactor <= maxScalingFactor) {
             "minScalingFactor ($minScalingFactor) must be <= maxScalingFactor ($maxScalingFactor)"
         }
+        require(scalingFactor in minScalingFactor..maxScalingFactor) {
+            "scalingFactor ($scalingFactor) must be between minScalingFactor ($minScalingFactor) and maxScalingFactor ($maxScalingFactor)"
+        }
     }
 }

--- a/library/src/main/java/de/tobiasschuerg/weekview/util/LocalTimeExt.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/util/LocalTimeExt.kt
@@ -3,9 +3,10 @@ package de.tobiasschuerg.weekview.util
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
+import java.util.Locale
 
 private val localTimeFormat: DateTimeFormatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
 
-internal fun LocalTime.toLocalString(): String {
-    return localTimeFormat.format(this)
+internal fun LocalTime.toLocalString(locale: Locale = Locale.getDefault()): String {
+    return localTimeFormat.withLocale(locale).format(this)
 }

--- a/library/src/test/java/de/tobiasschuerg/weekview/data/WeekDataTest.kt
+++ b/library/src/test/java/de/tobiasschuerg/weekview/data/WeekDataTest.kt
@@ -55,6 +55,53 @@ class WeekDataTest {
     }
 
     @Test
+    fun `adding and clearing events increments the change version`() {
+        val initialVersion = weekData.changeVersion
+        weekData.add(
+            Event.AllDay(
+                id = 20L,
+                date = LocalDate.of(2024, 9, 3),
+                title = "Changed",
+                shortTitle = "C",
+                textColor = 0,
+                backgroundColor = 0,
+            ),
+        )
+
+        assertEquals(initialVersion + 1, weekData.changeVersion)
+
+        weekData.clear()
+
+        assertEquals(initialVersion + 2, weekData.changeVersion)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `duplicate event ids are rejected across event types`() {
+        weekData.add(
+            Event.Single(
+                id = 21L,
+                date = LocalDate.of(2024, 9, 2),
+                title = "Timed",
+                shortTitle = "T",
+                timeSpan = TimeSpan.of(LocalTime.of(9, 0), Duration.ofHours(1)),
+                backgroundColor = 0,
+                textColor = 0,
+            ),
+        )
+
+        weekData.add(
+            Event.AllDay(
+                id = 21L,
+                date = LocalDate.of(2024, 9, 3),
+                title = "All day",
+                shortTitle = "AD",
+                textColor = 0,
+                backgroundColor = 0,
+            ),
+        )
+    }
+
+    @Test
     fun `clear removes all events`() {
         val event =
             Event.Single(

--- a/library/src/test/java/de/tobiasschuerg/weekview/data/WeekViewConfigTest.kt
+++ b/library/src/test/java/de/tobiasschuerg/weekview/data/WeekViewConfigTest.kt
@@ -1,0 +1,21 @@
+package de.tobiasschuerg.weekview.data
+
+import org.junit.Test
+
+class WeekViewConfigTest {
+    @Test(expected = IllegalArgumentException::class)
+    fun `scaling factor below minimum is rejected`() {
+        WeekViewConfig(
+            scalingFactor = 0.25f,
+            minScalingFactor = 0.5f,
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `scaling factor above maximum is rejected`() {
+        WeekViewConfig(
+            scalingFactor = 2.5f,
+            maxScalingFactor = 2f,
+        )
+    }
+}

--- a/library/src/test/java/de/tobiasschuerg/weekview/util/LocalDateExtTest.kt
+++ b/library/src/test/java/de/tobiasschuerg/weekview/util/LocalDateExtTest.kt
@@ -2,8 +2,15 @@ package de.tobiasschuerg.weekview.util
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import java.time.LocalDate
+import java.util.Locale
 
 class LocalDateExtTest {
+    @Test
+    fun `short date formatting uses supplied locale`() {
+        assertEquals("9/2", LocalDate.of(2024, 9, 2).toShortDateStringWithoutYear(Locale.US))
+    }
+
     @Test
     fun `removeYearFromPattern removes year from German short pattern`() {
         assertEquals("dd.MM", removeYearFromPattern("dd.MM.yy"))

--- a/library/src/test/java/de/tobiasschuerg/weekview/util/LocalTimeExtTest.kt
+++ b/library/src/test/java/de/tobiasschuerg/weekview/util/LocalTimeExtTest.kt
@@ -1,0 +1,27 @@
+package de.tobiasschuerg.weekview.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.LocalTime
+import java.util.Locale
+
+class LocalTimeExtTest {
+    @Test
+    fun `toLocalString formats using the requested locale, not the JVM default`() {
+        val time = LocalTime.of(9, 5)
+
+        assertEquals("9:05 AM", time.toLocalString(Locale.US))
+        assertEquals("09:05", time.toLocalString(Locale.GERMANY))
+    }
+
+    @Test
+    fun `toLocalString defaults to the JVM default locale when none is given`() {
+        val defaultLocale = Locale.getDefault()
+        try {
+            Locale.setDefault(Locale.GERMANY)
+            assertEquals(LocalTime.of(14, 30).toLocalString(Locale.GERMANY), LocalTime.of(14, 30).toLocalString())
+        } finally {
+            Locale.setDefault(defaultLocale)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Hoists pinch-zoom scaling and scroll state into a `WeekViewState` (via `rememberWeekViewState`), reducing unnecessary clock/recomposition churn.
- Adds clickable day headers (`onDayClick` on `WeekViewActions`), wired up in the sample app.
- Localizes day headers and event time text via an explicit `locale` parameter threaded through `WeekViewConfig` → `DayHeaderRow`/`EventCompose`, defaulting to the observable `LocalLocale.current.platformLocale` instead of a non-observable `Locale.getDefault()`.
- Hardens Compose data/config contracts (event semantics/identity, `WeekViewConfig` validation).
- Fixes found in review: clamps the persisted zoom state to the current `minScalingFactor`/`maxScalingFactor` on every recomposition (previously could crash if bounds tightened after a zoom), gates event clickability semantics on whether a click/long-press handler is actually supplied (matches `DayHeaderRow`'s existing pattern, fixes screen readers announcing non-interactive events as buttons), moves `WeekViewActions.onDayClick` to the end of the constructor to avoid a positional-arg/API-compatibility break, and threads the explicit `locale` through event time formatting.

## Test plan
- [x] `./gradlew clean build` (unit tests + lint) passes
- [x] `./gradlew connectedDebugAndroidTest` — 12/12 pass on a physical device
- [x] Manually verified day-header click and event click/long-press in the sample app