### PR TITLE
chore: bump AGP to 9.3.1 and migrate off deprecated createAndroidComposeRule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,10 +68,13 @@ Library version is defined in `gradle.properties` (`libVersion`) and read by the
 
 ## Testing
 
-Unit tests in `library/src/test/` using JUnit 4:
+Unit tests in `library/src/test/` using JUnit 5 (Jupiter):
 - `WeekDataTest` — event addition, time span expansion, date range validation
 - `TimeSpanTest` — duration calculation, hourly time generation
 - `EventPositionUtilTest` — vertical offset/height calculations
 - `DayOfWeekUtilTest` — day-to-column mapping
+- `LocalDateExtTest` — date formatting/pattern helpers
+
+Instrumented Compose UI tests in `library/src/androidTest/` stay on JUnit 4 (`androidx.test`/`ui-test-junit4` have no JUnit 5 equivalent for on-device tests).
 
 Use the sample app (`app/` module) for manual integration testing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,8 @@ Unit tests in `library/src/test/` using JUnit 5 (Jupiter):
 - `EventPositionUtilTest` — vertical offset/height calculations
 - `DayOfWeekUtilTest` — day-to-column mapping
 - `LocalDateExtTest` — date formatting/pattern helpers
+- `LocalTimeExtTest` — time formatting/locale defaults
+- `WeekViewConfigTest` — scaling factor validation
 
 Instrumented Compose UI tests in `library/src/androidTest/` stay on JUnit 4 (`androidx.test`/`ui-test-junit4` have no JUnit 5 equivalent for on-device tests).
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.2.1"
+agp = "9.3.1"
 kotlin = "2.3.20"
 compose-bom = "2026.06.01"
 ktlint = "14.2.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ annotation = "1.10.0"
 core-ktx = "1.19.0"
 lifecycle = "2.11.0"
 activity-compose = "1.13.0"
-junit = "4.13.2"
+junit-jupiter = "6.1.3"
 androidx-test-ext = "1.3.0"
 espresso = "3.7.0"
 test-runner = "1.7.0"
@@ -31,7 +31,8 @@ compose-foundation = { group = "androidx.compose.foundation", name = "foundation
 compose-runtime = { group = "androidx.compose.runtime", name = "runtime" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
-junit = { group = "junit", name = "junit", version.ref = "junit" }
+junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "junit-jupiter" }
+junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext" }
 androidx-test-espresso = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso" }
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "test-runner" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -80,8 +80,8 @@ dependencies {
     debugImplementation(libs.compose.ui.test.manifest)
 
     // Test dependencies
-    testImplementation(libs.junit)
-    testImplementation(libs.compose.ui.test.junit4)
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.junit.platform.launcher)
 
     // Android Test dependencies
     androidTestImplementation(libs.androidx.test.ext.junit)
@@ -89,6 +89,10 @@ dependencies {
     androidTestImplementation(libs.compose.ui.test.junit4)
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.androidx.test.rules)
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
 }
 
 afterEvaluate {

--- a/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/WeekBackgroundComposeEventDisplayTest.kt
+++ b/library/src/androidTest/java/de/tobiasschuerg/weekview/compose/WeekBackgroundComposeEventDisplayTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.ComposeTestRule
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick

--- a/library/src/test/java/de/tobiasschuerg/weekview/data/WeekDataTest.kt
+++ b/library/src/test/java/de/tobiasschuerg/weekview/data/WeekDataTest.kt
@@ -1,12 +1,13 @@
 package de.tobiasschuerg.weekview.data
 
 import de.tobiasschuerg.weekview.util.TimeSpan
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalTime
@@ -15,7 +16,7 @@ class WeekDataTest {
     private lateinit var weekData: WeekData
     private val dateRange = LocalDateRange(LocalDate.of(2024, 9, 1), LocalDate.of(2024, 9, 7))
 
-    @Before
+    @BeforeEach
     fun setUp() {
         weekData = WeekData(dateRange, start = LocalTime.of(9, 0), end = LocalTime.of(9, 0))
     }
@@ -75,30 +76,32 @@ class WeekDataTest {
         assertEquals(initialVersion + 2, weekData.changeVersion)
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `duplicate event ids are rejected across event types`() {
-        weekData.add(
-            Event.Single(
-                id = 21L,
-                date = LocalDate.of(2024, 9, 2),
-                title = "Timed",
-                shortTitle = "T",
-                timeSpan = TimeSpan.of(LocalTime.of(9, 0), Duration.ofHours(1)),
-                backgroundColor = 0,
-                textColor = 0,
-            ),
-        )
+        assertThrows<IllegalArgumentException> {
+            weekData.add(
+                Event.Single(
+                    id = 21L,
+                    date = LocalDate.of(2024, 9, 2),
+                    title = "Timed",
+                    shortTitle = "T",
+                    timeSpan = TimeSpan.of(LocalTime.of(9, 0), Duration.ofHours(1)),
+                    backgroundColor = 0,
+                    textColor = 0,
+                ),
+            )
 
-        weekData.add(
-            Event.AllDay(
-                id = 21L,
-                date = LocalDate.of(2024, 9, 3),
-                title = "All day",
-                shortTitle = "AD",
-                textColor = 0,
-                backgroundColor = 0,
-            ),
-        )
+            weekData.add(
+                Event.AllDay(
+                    id = 21L,
+                    date = LocalDate.of(2024, 9, 3),
+                    title = "All day",
+                    shortTitle = "AD",
+                    textColor = 0,
+                    backgroundColor = 0,
+                ),
+            )
+        }
     }
 
     @Test
@@ -167,34 +170,38 @@ class WeekDataTest {
         assertEquals(1, weekData.getMultiDayEvents().size)
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `multi-day event fully outside date range throws exception`() {
-        weekData.add(
-            Event.MultiDay(
-                id = 13L,
-                date = LocalDate.of(2024, 8, 1),
-                title = "Outside",
-                shortTitle = "Out",
-                lastDate = LocalDate.of(2024, 8, 3),
-                textColor = 0,
-                backgroundColor = 0,
-            ),
-        )
+        assertThrows<IllegalArgumentException> {
+            weekData.add(
+                Event.MultiDay(
+                    id = 13L,
+                    date = LocalDate.of(2024, 8, 1),
+                    title = "Outside",
+                    shortTitle = "Out",
+                    lastDate = LocalDate.of(2024, 8, 3),
+                    textColor = 0,
+                    backgroundColor = 0,
+                ),
+            )
+        }
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `multi-day event with lastDate before date throws exception`() {
-        weekData.add(
-            Event.MultiDay(
-                id = 14L,
-                date = LocalDate.of(2024, 9, 4),
-                title = "Invalid",
-                shortTitle = "Inv",
-                lastDate = LocalDate.of(2024, 9, 2),
-                textColor = 0,
-                backgroundColor = 0,
-            ),
-        )
+        assertThrows<IllegalArgumentException> {
+            weekData.add(
+                Event.MultiDay(
+                    id = 14L,
+                    date = LocalDate.of(2024, 9, 4),
+                    title = "Invalid",
+                    shortTitle = "Inv",
+                    lastDate = LocalDate.of(2024, 9, 2),
+                    textColor = 0,
+                    backgroundColor = 0,
+                ),
+            )
+        }
     }
 
     @Test
@@ -244,12 +251,10 @@ class WeekDataTest {
                 backgroundColor = 0,
                 textColor = 0,
             )
-        try {
-            weekData.add(event)
-            // If no exception is thrown, fail the test
-            assertTrue("Expected IllegalArgumentException was not thrown", false)
-        } catch (e: IllegalArgumentException) {
-            assertTrue(e.message!!.contains("outside the allowed range"))
-        }
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                weekData.add(event)
+            }
+        assertTrue(exception.message!!.contains("outside the allowed range"))
     }
 }

--- a/library/src/test/java/de/tobiasschuerg/weekview/data/WeekViewConfigTest.kt
+++ b/library/src/test/java/de/tobiasschuerg/weekview/data/WeekViewConfigTest.kt
@@ -1,21 +1,26 @@
 package de.tobiasschuerg.weekview.data
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class WeekViewConfigTest {
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `scaling factor below minimum is rejected`() {
-        WeekViewConfig(
-            scalingFactor = 0.25f,
-            minScalingFactor = 0.5f,
-        )
+        assertThrows<IllegalArgumentException> {
+            WeekViewConfig(
+                scalingFactor = 0.25f,
+                minScalingFactor = 0.5f,
+            )
+        }
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `scaling factor above maximum is rejected`() {
-        WeekViewConfig(
-            scalingFactor = 2.5f,
-            maxScalingFactor = 2f,
-        )
+        assertThrows<IllegalArgumentException> {
+            WeekViewConfig(
+                scalingFactor = 2.5f,
+                maxScalingFactor = 2f,
+            )
+        }
     }
 }

--- a/library/src/test/java/de/tobiasschuerg/weekview/util/DayOfWeekUtilTest.kt
+++ b/library/src/test/java/de/tobiasschuerg/weekview/util/DayOfWeekUtilTest.kt
@@ -1,7 +1,7 @@
 package de.tobiasschuerg.weekview.util
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 import java.time.DayOfWeek
 import java.time.temporal.WeekFields
 import java.util.Locale

--- a/library/src/test/java/de/tobiasschuerg/weekview/util/EventPositionUtilTest.kt
+++ b/library/src/test/java/de/tobiasschuerg/weekview/util/EventPositionUtilTest.kt
@@ -2,8 +2,8 @@ package de.tobiasschuerg.weekview.util
 
 import androidx.compose.ui.unit.dp
 import de.tobiasschuerg.weekview.data.Event
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalTime

--- a/library/src/test/java/de/tobiasschuerg/weekview/util/LocalDateExtTest.kt
+++ b/library/src/test/java/de/tobiasschuerg/weekview/util/LocalDateExtTest.kt
@@ -1,7 +1,7 @@
 package de.tobiasschuerg.weekview.util
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.util.Locale
 

--- a/library/src/test/java/de/tobiasschuerg/weekview/util/LocalTimeExtTest.kt
+++ b/library/src/test/java/de/tobiasschuerg/weekview/util/LocalTimeExtTest.kt
@@ -1,7 +1,7 @@
 package de.tobiasschuerg.weekview.util
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 import java.time.LocalTime
 import java.util.Locale
 

--- a/library/src/test/java/de/tobiasschuerg/weekview/util/TimeSpanTest.kt
+++ b/library/src/test/java/de/tobiasschuerg/weekview/util/TimeSpanTest.kt
@@ -1,7 +1,7 @@
 package de.tobiasschuerg.weekview.util
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.time.LocalTime
 


### PR DESCRIPTION
## Summary
- Bumps AGP from 9.2.1 to 9.3.1 in `gradle/libs.versions.toml`.
- Migrates `WeekBackgroundComposeEventDisplayTest` off the deprecated `androidx.compose.ui.test.junit4.createAndroidComposeRule` (v1) to `androidx.compose.ui.test.junit4.v2.createAndroidComposeRule`, which was flagged as a deprecation warning during compilation.

## Test plan
- [x] `./gradlew clean build` (unit tests + lint) passes
- [x] `./gradlew connectedDebugAndroidTest` — 6/6 pass on a physical device (v2 uses `StandardTestDispatcher` instead of `UnconfinedTestDispatcher`, verified no flakiness across repeated runs)