### PR TITLE
docs: describe priority-based field visibility, fix stale version/sample count

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ val eventConfig = EventConfig(
 )
 ```
 
+Events adapt their layout to the available height automatically, dropping fields by
+priority (name > time > location > teacher) rather than clipping whatever renders first:
+
+- Short entries show only the name; time, location, and teacher are added back in as
+  the entry gets taller.
+- The start/end time is one combined line (`"09:00 - 10:30"`) until the entry is tall
+  enough to split into two labels — start at the top, end pinned to the bottom.
+- The title wraps onto a second line instead of eliding once there's room to spare.
+
 ### Callbacks
 
 ```kotlin
@@ -145,7 +154,7 @@ In your **app** `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("com.github.tobiasschuerg:android-week-view:4.0.0")
+    implementation("com.github.tobiasschuerg:android-week-view:4.2.0")
 
     // Required for Compose
     implementation(platform("androidx.compose:compose-bom:2026.02.00"))
@@ -166,7 +175,7 @@ dependencies {
 
 ## Sample App
 
-The `app/` module contains a sample app with four built-in timetables (University, Work, School, Conference) demonstrating different layouts, overlapping events, all-day/multi-day events, and a 3-day view. Switch between them via the top app bar menu.
+The `app/` module contains a sample app with five built-in timetables (University, Work, School, Conference, Special Cases) demonstrating different layouts, overlapping events, all-day/multi-day events, a 3-day view, and rendering edge cases like very short entries and long titles. Switch between them via the top app bar menu.
 
 ## Contributing
 

--- a/library/src/main/java/de/tobiasschuerg/weekview/data/EventConfig.kt
+++ b/library/src/main/java/de/tobiasschuerg/weekview/data/EventConfig.kt
@@ -2,20 +2,27 @@ package de.tobiasschuerg.weekview.data
 
 /**
  * Configures the appearance of an event in the week view.
+ *
+ * The fields below enable a piece of content; whether it actually renders can still
+ * depend on the entry's height. The title is always shown; time, then location
+ * (subtitle), then upper text are dropped in that order on entries too short to fit
+ * everything, so the most useful information survives rather than whatever happens to
+ * be first in the layout. See [de.tobiasschuerg.weekview.util.EventPositionUtil] for
+ * the height thresholds.
  */
 data class EventConfig(
     /** If true, always uses the full event title in both portrait and landscape mode.
      * If false (default), uses short event names in portrait mode and full names in landscape mode. */
     val alwaysUseFullName: Boolean = false,
-    /** Show the event start time in the event view. */
+    /** Show the event start time in the event view, room permitting. */
     val showTimeStart: Boolean = true,
-    /** Show the upper text field of the event. */
+    /** Show the upper text field of the event, room permitting. */
     val showUpperText: Boolean = true,
-    /** Show the event subtitle below the title. */
+    /** Show the event subtitle below the title, room permitting. */
     val showSubtitle: Boolean = true,
-    /** Show the lower text field of the event. */
+    /** Show the lower text field of the event, room permitting. */
     val showLowerText: Boolean = true,
-    /** Show the event end time in the event view. */
+    /** Show the event end time in the event view, room permitting. */
     val showTimeEnd: Boolean = true,
     /** Spacing in dp between adjacent events. Set to 0 for no spacing. */
     val eventSpacingDp: Int = 1,


### PR DESCRIPTION
Follow-up to #85, which merged before this docs commit made it in.

- README's installation snippet still pointed at `4.0.0`; current release is `4.2.0`.
- Sample app description said four timetables; there are now five (added "Special Cases").
- Documents the new space-aware field visibility (priority-based dropping, time-label split, 2-line title) on `EventConfig` and in the README's Event Configuration section.

No code behavior changes, docs only.